### PR TITLE
fix: grant workflows permission to dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,6 +15,11 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
+  # Needed specifically for Dependabot PRs that touch .github/workflows/*
+  # (e.g. github-actions ecosystem updates) — without this, the merge is
+  # refused with "refusing to allow a GitHub App to ... update workflow
+  # ... without `workflows` permission".
+  workflows: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
## Summary
- PR #10's auto-merge attempt failed: `refusing to allow a GitHub App to create or update workflow .github/workflows/codeql-analysis.yml without workflows permission`
- Dependabot PRs on the `github-actions` ecosystem modify files under `.github/workflows/*`, which requires the `workflows` permission scope on the token used to merge — `dependabot-automerge.yml` only granted `contents`/`pull-requests`.
- Added `workflows: write` to the workflow's `permissions` block.

## Test plan
- [ ] Merge this PR
- [ ] Re-run auto-merge on PR #10 (or wait for the next `github-actions` Dependabot PR) and confirm it merges cleanly