### PR TITLE
fix: revert invalid workflows permission on dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -6,8 +6,18 @@
 #   2. Settings -> Branches -> add a protection rule for `main` that requires
 #      the `Backend tests (pytest)` and `Frontend tests (vitest)` status
 #      checks (from ci.yml) before merging.
-# Without both of those, `gh pr merge --auto` below will queue the merge but
-# it will never actually complete.
+#   3. A repo secret named DEPENDABOT_AUTOMERGE_PAT: a classic GitHub PAT
+#      with the `repo` + `workflow` scopes. The default GITHUB_TOKEN is
+#      unconditionally blocked by GitHub from writing to
+#      .github/workflows/* (this can't be granted via `permissions:` --
+#      `workflows` is not a valid key there, and there is no key that
+#      unlocks it for GITHUB_TOKEN). Without this secret, PRs on the
+#      `github-actions` Dependabot ecosystem (which touch workflow files)
+#      will fail to auto-merge even though everything else works; the step
+#      below falls back to GITHUB_TOKEN if the secret isn't set, so npm/pip
+#      PRs still auto-merge fine in the meantime.
+# Without all three, `gh pr merge --auto` below will queue the merge but it
+# will never actually complete (or, for workflow-file PRs, will fail outright).
 name: Dependabot auto-merge
 
 on: pull_request
@@ -31,4 +41,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,11 +15,6 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
-  # Needed specifically for Dependabot PRs that touch .github/workflows/*
-  # (e.g. github-actions ecosystem updates) — without this, the merge is
-  # refused with "refusing to allow a GitHub App to ... update workflow
-  # ... without `workflows` permission".
-  workflows: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
## Summary
- #11 added `workflows: write` to `dependabot-automerge.yml`'s `permissions:` block to try to fix auto-merge failing on github-actions-ecosystem PRs. `workflows` is not a valid `permissions:` key, so the whole workflow file has been failing to parse since #11 merged -- every trigger since then is a 0-second "failure" with zero jobs scheduled, which is worse than the original bug (it broke *all* Dependabot PRs, not just workflow-file ones). This reverts that.
- Adds proper support instead: the merge step now uses an optional `DEPENDABOT_AUTOMERGE_PAT` secret (falling back to `GITHUB_TOKEN` if unset) because the default `GITHUB_TOKEN` is unconditionally blocked by GitHub from writing to `.github/workflows/*` -- there's no `permissions:` key that unlocks this for GITHUB_TOKEN, it needs a real PAT or GitHub App token.

## Manual step needed after merging this PR
1. Create a classic PAT: https://github.com/settings/tokens/new -- scopes: `repo` and `workflow`. Set an expiration you're comfortable with (it'll need renewing).
2. Add it as a repo secret named `DEPENDABOT_AUTOMERGE_PAT`:
   ```
   gh secret set DEPENDABOT_AUTOMERGE_PAT --repo nikkel/Job_Queue
   ```
   (prompts for the value interactively -- or use Settings -> Secrets and variables -> Actions in the web UI instead, same effect, avoids the token ever touching your shell history)

## Test plan
- [ ] Merge this PR
- [ ] Add the `DEPENDABOT_AUTOMERGE_PAT` secret
- [ ] Confirm the codeql-action PR (or the next github-actions Dependabot PR) auto-merges successfully
- [ ] Confirm npm/pip Dependabot PRs still auto-merge fine even before the secret is added (fallback to GITHUB_TOKEN)