### PR TITLE
fix: react-spinners import breaks the app UI (Vite 8 CJS interop bug)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@ import Dashboard from './components/Dashboard/Dashboard';
 import { userContext } from './contexts/userContext';
 import Api from './api';
 
-import CircleLoader from 'react-spinners/CircleLoader';
+import { CircleLoader } from 'react-spinners';
 import { css } from '@emotion/react';
 import './App.css';
 

--- a/frontend/src/components/TaskTable/TaskTable.jsx
+++ b/frontend/src/components/TaskTable/TaskTable.jsx
@@ -40,7 +40,6 @@ const TaskTable = () => {
       ${customer.result}
       `,
       text: `result: ${customer.result}.`,
-      isUploading: false,
     });
   };
 

--- a/frontend/src/components/TaskTable/TaskTable.jsx
+++ b/frontend/src/components/TaskTable/TaskTable.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import Api from '../../api';
 import Swal from 'sweetalert2';
-import PropagateLoader from 'react-spinners/PropagateLoader';
+import { PropagateLoader } from 'react-spinners';
 
 const TaskTable = () => {
   const [data, setData] = useState([]);

--- a/frontend/src/components/TaskTable/TaskTable.jsx
+++ b/frontend/src/components/TaskTable/TaskTable.jsx
@@ -46,6 +46,17 @@ const TaskTable = () => {
 
   return (
     <div className='row'>
+      <PropagateLoader
+        color={'#000000'}
+        loading={isLoading}
+        cssOverride={{
+          position: 'absolute',
+          left: '50%',
+          transform: 'translate(-50%)',
+          padding: '10px',
+        }}
+        size={10}
+      />
       <table className='table table-bordered'>
         <thead className='thead-light'>
           <tr>
@@ -58,17 +69,6 @@ const TaskTable = () => {
           </tr>
         </thead>
         <tbody>
-          <PropagateLoader
-            color={'#000000'}
-            loading={isLoading}
-            cssOverride={{
-              position: 'absolute',
-              left: '50%',
-              transform: 'translate(-50%)',
-              padding: '10px',
-            }}
-            size={10}
-          />
           {data &&
             data.map((task) => (
               <tr key={task.id}>

--- a/frontend/src/components/TaskTable/TaskTable.test.jsx
+++ b/frontend/src/components/TaskTable/TaskTable.test.jsx
@@ -37,6 +37,16 @@ describe('TaskTable', () => {
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
+  test('the loading spinner is not nested inside tbody (only <tr> is valid there)', () => {
+    Api.task.getAll.mockResolvedValue({ tasks: [] });
+    const { container } = render(<TaskTable />);
+
+    const tbody = container.querySelector('tbody');
+    for (const child of tbody.children) {
+      expect(child.tagName).toBe('TR');
+    }
+  });
+
   test('polls the task list and renders fetched rows', async () => {
     Api.task.getAll.mockResolvedValue({
       tasks: [

--- a/frontend/src/components/TaskTable/TaskTable.test.jsx
+++ b/frontend/src/components/TaskTable/TaskTable.test.jsx
@@ -91,6 +91,12 @@ describe('TaskTable', () => {
     expect(Swal.fire).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Job ID: 7' })
     );
+    // Regression check: only real SweetAlert2 options should be passed --
+    // this call used to include a stray `isUploading` key (copy-paste
+    // leftover from UploadBox's unrelated state) that SweetAlert2 warns
+    // about as an unknown parameter.
+    const callArgs = Swal.fire.mock.calls[0][0];
+    expect(Object.keys(callArgs).sort()).toEqual(['html', 'text', 'title']);
   });
 
   test('silently handles a failed fetch', async () => {


### PR DESCRIPTION
## Summary
Three related UI bugs found while getting `docker-compose up --build --scale workers=3` to actually render correctly, in the order they surfaced (each one was masking the next):

1. **`react-spinners` subpath imports break under Vite 8**: blank page, `Uncaught Error: Element type is invalid: expected a string ... but got: object. Check the render method of App.` Root cause: Vite 8's Rolldown-based dependency pre-bundler doesn't correctly unwrap CJS interop for `react-spinners`'s subpath imports (`react-spinners/CircleLoader`, `react-spinners/PropagateLoader`) -- the pre-bundled chunk does `export default require_CircleLoader()`, exporting the raw `{ __esModule, default }` object instead of unwrapping to the component. Verified directly against the dev server's actual transformed module output. Fixed by importing `{ CircleLoader }`/`{ PropagateLoader }` from the `react-spinners` package root instead of the subpath -- the root entry point does its own interop unwrapping internally.
2. **`<span> cannot be a child of <tbody>`**: once bug 1 was fixed, this showed up. `PropagateLoader` renders a `<span>` wrapper and it was placed directly inside `<tbody>` alongside `<tr>` rows, which is invalid HTML. Predates this PR; was masked by bug 1 crashing the render first. Fixed by moving the loader to be a sibling of `<table>` instead of a `<tbody>` child. Added a regression test asserting `tbody` only ever contains `<tr>` children.
3. **`SweetAlert2: Unknown parameter "isUploading"`**: the job-detail popup (`TaskTable`'s `togglePopup`) passed `isUploading: false` to `Swal.fire`, which isn't a real SweetAlert2 option -- looks like copy-paste leftover from `UploadBox`'s unrelated `isUploading` state. Removed it. Added a regression test asserting only real SweetAlert2 keys are passed.

## Test plan
- [x] `npm run test` -- 35/35 passing
- [x] `npm run build` -- succeeds
- [x] Verified against the dev server's raw module output that `CircleLoader`/`PropagateLoader` now resolve to the actual component functions
- [ ] `docker-compose up --build --scale workers=3` and confirm the UI loads with no console errors